### PR TITLE
"fix: tsc error while checking"

### DIFF
--- a/src/QRCodeVue3.vue
+++ b/src/QRCodeVue3.vue
@@ -103,6 +103,10 @@ export default defineComponent({
     downloadOptions: {
       type: Object,
       default: () => ({ name: "vqr", extension: "png" })
+    },
+    onDownloadClick: {
+      type: Function,
+      default: () => ({}),
     }
   },
   data() {


### PR DESCRIPTION
`vue-tsc --noEmit` will produce this error

node_modules/qrcode-vue3/src/QRCodeVue3.vue:7:23 - Property 'onDownloadClick' does not exist on type 'Vue3Instance<{ imageUrl: string; qrCode: QRCodeStyling; }, Readonly<ExtractPropTypes<{ width: { type: NumberConstructor; default: number; }; imgclass: { type: StringConstructor; default: string; }; ... 14 more ...; downloadOptions: { ...; }; }>>, ... 4 more ..., ComponentOptionsBase<...>> & ... 5 more ... & Readonly...'.

had no other option, caused of `--skipLibCheck` didn't work for skipping check library