### PR TITLE
Update Importing Modules

### DIFF
--- a/src/core/QRCodeStyling.ts
+++ b/src/core/QRCodeStyling.ts
@@ -5,7 +5,7 @@ import QRCanvas from "./QRCanvas";
 import defaultOptions, { type Options, type RequiredOptions } from "./QROptions";
 import sanitizeOptions from "../tools/sanitizeOptions";
 import type { Extension, QRCode } from "../types";
-import qrcode from "qrcode-generator";
+import * as qr from "qrcode-generator";
 
 type DownloadOptions = {
   name?: string;
@@ -38,7 +38,7 @@ export default class QRCodeStyling {
       return;
     }
 
-    this._qr = <QRCode>qrcode(this._options.qrOptions.typeNumber, this._options.qrOptions.errorCorrectionLevel);
+    this._qr = <QRCode>qr.default(this._options.qrOptions.typeNumber, this._options.qrOptions.errorCorrectionLevel);
     this._qr.addData(this._options.data, this._options.qrOptions.mode || getMode(this._options.data));
     this._qr.make();
     this._canvas = new QRCanvas(this._options);


### PR DESCRIPTION
When the code runs in Nuxt3 production mode, the following error comes up: "The requested module 'qrcode-vue3' does not provide an export named 'default'." This issue is mentioned in #36. Another user in the thread proposed a solution using `import QRCodeVue3 from "qrcode-vue3/src/QRCodeVue3.vue";` 

However, this issue works in production mode but fails in development mode. The error is the same ("The requested module 'qrcode-vue3' does not provide an export named 'default') and comes from the 'QRCodeStyling.ts' file. I changed the way the qrcode-generator module is imported. This seems to fix the issue for my project and works on both dev and production mode.